### PR TITLE
解决不同本地开发环境问题-执行 npm run dev 时会报错 TypeError: webpack.validateSchema is…

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "style-loader": "^0.13.1",
     "vue-loader": "^9.5.1",
     "webpack": "2.1.0-beta.22",
-    "webpack-dev-server": "^2.1.0-beta.0"
+    "webpack-dev-server": "2.1.0-beta.10"
   }
 }


### PR DESCRIPTION
正如该项目Github的Issue#4所描述, 下载源代码后, 在本地执行以下命令
```
npm install
npm run dev
```
的时候, 会遇到TypeError: webpack.validateSchema is not a function问题. 这个问题是由于webpack-dev-server的版本所致.

建议:
为了解决不同本地开发环境问题, 在package.json中, 固定webpack-dev-server的版本为2.1.0-beta.10.
更多信息, 请参考:
http://stackoverflow.com/questions/40597626/webpack-validateschema-is-not-a-function?answertab=votes#tab-top
BartBiczBorzy在Nov 15 '16 at 5:16的回答.
